### PR TITLE
Make repository public and add workflows

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,0 +1,40 @@
+name: "Code Scanning"
+
+on:
+  push:
+    branches: [ "main", "dev" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  codeql:
+    name: "CodeQL Analysis"
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      matrix:
+        language: [ 'javascript', 'typescript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'typescript', 'python', 'ruby' ]
+        # Learn more: https://docs.github.com/en/code-security/codeql/codeql-supported-languages-and-frameworks
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: "Release"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: "Create Release"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate release notes
+        id: release_notes
+        uses: github/gh-release-notes@v0.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/release-notes.yml
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.sha }}
+          release_name: Release ${{ github.sha }}
+          body: ${{ steps.release_notes.outputs.notes }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/sync-dev-main.yml
+++ b/.github/workflows/sync-dev-main.yml
@@ -1,0 +1,26 @@
+name: Sync Dev and Main Branches
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+
+      - name: Sync branches
+        run: |
+          git checkout main
+          git pull origin main
+          git merge dev
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -80,3 +80,33 @@ Project Link: [https://github.com/KdogDevs/shift2stream-website](https://github.
 - [Vite](https://vitejs.dev/)
 - [Framer Motion](https://www.framer.com/motion/)
 - [Tailwind CSS](https://tailwindcss.com/)
+
+## Workflows and Deployment
+
+This repository uses GitHub Actions for various workflows and deployment processes. Below are the details of the workflows:
+
+### Code Scanning
+
+A GitHub Actions workflow is set up for code scanning to ensure the security and quality of the codebase. The workflow is defined in `.github/workflows/code-scanning.yml`.
+
+### Automatic Releases
+
+A GitHub Actions workflow is set up for automatic releases when a push is made to the `main` branch. The workflow generates release notes using Copilot. The workflow is defined in `.github/workflows/release.yml`.
+
+### Branch Syncing
+
+A GitHub Actions workflow is set up to sync the `dev` branch with the `main` branch. This ensures that all changes are staged in the `dev` branch before being merged into the `main` branch. The workflow is defined in `.github/workflows/sync-dev-main.yml`.
+
+## Contribution Instructions
+
+To contribute to this repository, please follow these steps:
+
+1. Fork the repository to your own GitHub account.
+2. Clone the forked repository to your local machine.
+3. Create a new branch for your changes (`git checkout -b feature/YourFeature`).
+4. Make your changes and commit them (`git commit -m 'Add YourFeature'`).
+5. Push your changes to your forked repository (`git push origin feature/YourFeature`).
+6. Open a pull request from your forked repository to the original repository.
+7. All pull requests must be approved by the repository owner before being merged.
+8. Only the repository owner can edit the branches directly.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift2stream-new",
-  "private": true,
+  "private": false,
   "version": "0.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Related to #27

Make the repository public and add GitHub Actions workflows for code scanning, automatic releases, and branch syncing.

* **Make Repository Public**
  - Change `"private"` to `false` in `package.json`.

* **Update Documentation**
  - Add sections on workflows and deployment processes in `README.md`.
  - Update contribution instructions to specify forking and pull request approval.

* **Add GitHub Actions Workflows**
  - Add `code-scanning.yml` for code scanning.
  - Add `release.yml` for automatic releases with Copilot-generated notes.
  - Add `sync-dev-main.yml` for syncing `dev` and `main` branches.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdogDevs/shift2stream-website/pull/28?shareId=3c636992-6a69-456a-ab02-197d1510a1e3).