### PR TITLE
Fix release notes action in GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Generate release notes
         id: release_notes
-        uses: github/gh-release-notes@v0.1.0
+        uses: github/gh-release-notes@v0.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/release-notes.yml

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A GitHub Actions workflow is set up for code scanning to ensure the security and
 
 ### Automatic Releases
 
-A GitHub Actions workflow is set up for automatic releases when a push is made to the `main` branch. The workflow generates release notes using Copilot. The workflow is defined in `.github/workflows/release.yml`.
+A GitHub Actions workflow is set up for automatic releases when a push is made to the `main` branch. The workflow generates release notes using `github/gh-release-notes@v0.2.0`. The workflow is defined in `.github/workflows/release.yml`.
 
 ### Branch Syncing
 


### PR DESCRIPTION
Update the GitHub Actions workflow to resolve the `github/gh-release-notes` repository issue.

* **README.md**
  - Update the description of the release workflow to reflect the new version of `github/gh-release-notes`.

* **.github/workflows/release.yml**
  - Update the `uses` field for the `Generate release notes` step to `github/gh-release-notes@v0.2.0`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdogDevs/shift2stream-website/pull/29?shareId=654bc817-9cd9-413a-aee0-04c4195272ac).