### PR TITLE
Fix GitHub Actions permissions to adhere to the principle of least privilege

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   release:
     name: "Create Release"

--- a/.github/workflows/sync-dev-main.yml
+++ b/.github/workflows/sync-dev-main.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ A GitHub Actions workflow is set up for automatic releases when a push is made t
 
 A GitHub Actions workflow is set up to sync the `dev` branch with the `main` branch. This ensures that all changes are staged in the `dev` branch before being merged into the `main` branch. The workflow is defined in `.github/workflows/sync-dev-main.yml`.
 
+### Permissions Settings for GitHub Actions Workflows
+
+To adhere to the principle of least privilege, the following permissions settings have been applied to the GitHub Actions workflows:
+
+- The `.github/workflows/release.yml` workflow specifies `permissions: contents: read, issues: write`.
+- The `.github/workflows/sync-dev-main.yml` workflow specifies `permissions: contents: read, pull-requests: write`.
+
 ## Contribution Instructions
 
 To contribute to this repository, please follow these steps:


### PR DESCRIPTION
Add explicit permissions to GitHub Actions workflows to adhere to the principle of least privilege.

* **README.md**
  - Add a section addressing the permissions settings for GitHub Actions workflows.

* **.github/workflows/release.yml**
  - Add `permissions: contents: read, issues: write` at the top level of the workflow.

* **.github/workflows/sync-dev-main.yml**
  - Add `permissions: contents: read, pull-requests: write` at the top level of the workflow.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdogDevs/shift2stream-website/pull/38?shareId=7660cb51-2c0b-4e57-a4a1-0156d94c0e9c).