### PR TITLE
Update Vite to version 5.4.12 or later

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,10 @@ updates:
     commit-message:
       prefix: "npm"
       include: "scope"
+    # Specify Vite version upgrade
+    allow:
+      - dependency-name: "vite"
+        version: ">=5.4.12"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-router-dom": "^6.22.1",
     "react-vertical-timeline-component": "^3.6.0",
     "styled-components": "^6.1.8",
-    "tailwind-merge": "^2.2.1"
+    "tailwind-merge": "^2.2.1",
+    "vite": ">=5.4.12"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",
@@ -47,6 +48,6 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
     "typescript-eslint": "^0.0.1-alpha.0",
-    "vite": "^5.1.3"
+    "vite": ">=5.4.12"
   }
 }


### PR DESCRIPTION
Update Vite to version 5.4.12 or later to address security vulnerabilities.

* **package.json**
  - Update `vite` version to ">=5.4.12" in `devDependencies`.
  - Add `vite` version ">=5.4.12" to `dependencies`.

* **.github/dependabot.yml**
  - Add `vite` version upgrade to 5.4.12 or later in `updates` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdogDevs/shift2stream-website/pull/39?shareId=e1c99ef8-fc6b-4258-9fe0-7ca203c64bcd).