### PR TITLE
Fix build command in package.json and README

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
Update the `dev` script in `package.json` to `vite build`.

* Change the `dev` script from `vite` to `vite build` to ensure the build command outputs to the `dist` folder.
* Ensure the `build` script remains unchanged.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdogDevs/shift2stream-website/pull/44?shareId=4f9966db-a56b-4c09-9c43-51f39c4421c6).