### PR TITLE
Fix GitHub Releases action by creating a tag before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,15 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Create Tag
+        id: tag
+        run: |
+          TAG_NAME="v$(date +'%Y%m%d%H%M%S')"
+          echo "Creating tag $TAG_NAME"
+          git tag $TAG_NAME
+          git push origin $TAG_NAME
+          echo "::set-output name=tag::$TAG_NAME"
+
       - name: Generate release notes
         id: release_notes
         run: |
@@ -31,6 +40,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
           body: ${{ steps.release_notes.outputs.notes }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ A GitHub Actions workflow is set up for code scanning to ensure the security and
 
 A GitHub Actions workflow is set up for automatic releases when a push is made to the `main` branch. The workflow generates release notes using `softprops/action-gh-release@v1`. The workflow is defined in `.github/workflows/release.yml`.
 
+#### Tag Creation Step
+
+The automatic release workflow now includes a step to create a tag before running the release step. This ensures that a tag is always available for the GitHub Releases action. The tag is created based on the current date and time.
+
 ### Branch Syncing
 
 A GitHub Actions workflow is set up to sync the `dev` branch with the `main` branch. This ensures that all changes are staged in the `dev` branch before being merged into the `main` branch. The workflow is defined in `.github/workflows/sync-dev-main.yml`.


### PR DESCRIPTION
Add a step to create a tag before the release step in the GitHub Actions workflow.

* **README.md**
  - Add a note about the new tag creation step in the "Automatic Releases" section.

* **.github/workflows/release.yml**
  - Add a step to create a tag based on the current date and time before the release step.
  - Update the `Create GitHub release` step to use the created tag.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdogDevs/shift2stream-website/pull/49?shareId=a55b349c-cd72-47c1-82ba-3bbbeb3be6c7).