### PR TITLE
Fix GitHub Actions permissions to push tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Create Tag
         id: tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
           TAG_NAME="v$(date +'%Y%m%d%H%M%S')"
           echo "Creating tag $TAG_NAME"

--- a/README.md
+++ b/README.md
@@ -133,3 +133,17 @@ A new GitHub Actions workflow has been added to handle automatic releases whenev
 
 The auto-release workflow leverages GitHub Copilot to generate release notes. This ensures that the release notes are comprehensive and accurately reflect the changes made in each release.
 
+## Creating a Personal Access Token (PAT)
+
+To ensure that the GitHub Actions bot has the necessary permissions to push the tag to the repository, follow these steps to create a personal access token (PAT):
+
+1. Go to GitHub Settings and generate a new token with `repo` scope.
+2. Store the PAT as a secret in your repository settings.
+
+## Storing the PAT as a Secret
+
+To store the PAT as a secret named `PAT` in the repository settings, follow these steps:
+
+1. Go to your repository's settings.
+2. Navigate to the "Secrets" section.
+3. Create a new secret called `PAT` and paste the generated token.


### PR DESCRIPTION
Update the GitHub Actions workflow to use a personal access token (PAT) for authentication to push tags.

* **README.md**
  - Add instructions to create a personal access token (PAT) with the required permissions.
  - Add instructions to store the PAT as a secret named `PAT` in the repository settings.

* **.github/workflows/release.yml**
  - Update the `Create Tag` step to use the PAT for authentication by setting the `GITHUB_TOKEN` environment variable to `${{ secrets.PAT }}`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdogDevs/shift2stream-website/pull/50?shareId=0f62335b-21a8-471a-96dd-5be59e68eec3).